### PR TITLE
Rename device_state_attributes to extra_state_attributes

### DIFF
--- a/custom_components/carbon_intensity_uk/entity.py
+++ b/custom_components/carbon_intensity_uk/entity.py
@@ -34,7 +34,7 @@ class CarbonIntensityEntity(entity.Entity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return self.coordinator.data
 


### PR DESCRIPTION
Since HA 2022.4, `device_state_attributes` no longer works. We need to use `extra_state_attributes` instead. https://github.com/home-assistant/core/pull/67837
https://developers.home-assistant.io/blog/2022/03/30/2022.4-new-dev-features/

Fixes #9 